### PR TITLE
Added browser.versionNumber and linted jquery.browser.js.

### DIFF
--- a/jquery.browser.js
+++ b/jquery.browser.js
@@ -15,13 +15,13 @@
 
 (function( jQuery, window, undefined ) {
 "use strict";
- 
+
 var matched, browser;
- 
+
 jQuery.uaMatch = function( ua ) {
   ua = ua.toLowerCase();
- 
-	var match = /(opr)[\/]([\w.]+)/.exec( ua ) || 
+
+	var match = /(opr)[\/]([\w.]+)/.exec( ua ) ||
 		/(chrome)[ \/]([\w.]+)/.exec( ua ) ||
 		/(version)[ \/]([\w.]+).*(safari)[ \/]([\w.]+)/.exec(ua) ||
 		/(webkit)[ \/]([\w.]+)/.exec( ua ) ||
@@ -39,43 +39,44 @@ jQuery.uaMatch = function( ua ) {
 		/(mac)/.exec( ua ) ||
 		/(linux)/.exec( ua ) ||
 		[];
- 
+
 	return {
 		browser: match[ 3 ] || match[ 1 ] || "",
 		version: match[ 2 ] || "0",
 		platform: platform_match[0] || ""
 	};
 };
- 
+
 matched = jQuery.uaMatch( window.navigator.userAgent );
 browser = {};
- 
+
 if ( matched.browser ) {
 	browser[ matched.browser ] = true;
 	browser.version = matched.version;
+    browser.versionNumber = parseFloat(matched.version, 10);
 }
 
-if ( matched.platform) {
-	browser[ matched.platform ] = true
+if ( matched.platform ) {
+	browser[ matched.platform ] = true;
 }
- 
+
 // Chrome, Opera 15+ and Safari are webkit based browsers
-if ( browser.chrome || browser.opr || browser.safari) {
+if ( browser.chrome || browser.opr || browser.safari ) {
 	browser.webkit = true;
 }
 
 // IE11 has a new token so we will assign it msie to avoid breaking changes
-if (browser.rv)
+if ( browser.rv )
 {
 	browser.msie = true;
 }
 
 // Opera 15+ are identified as opr
-if (browser.opr)
+if ( browser.opr )
 {
 	browser.opera = true;
 }
- 
+
 jQuery.browser = browser;
- 
+
 })( jQuery, window );

--- a/jquery.browser.js.coffee
+++ b/jquery.browser.js.coffee
@@ -1,7 +1,7 @@
 #!
 # jQuery Browser Plugin v0.0.4
 # https://github.com/gabceb/jquery-browser-plugin
-# 
+#
 # Original jquery-browser code Copyright 2005, 2013 jQuery Foundation, Inc. and other contributors
 # http://jquery.org/license
 #
@@ -11,7 +11,7 @@
 # Released under the MIT license
 #
 # Date: 2013-07-29T17:23:27-07:00
-# 
+#
 
 ((jQuery, window, undefined_) ->
   "use strict"
@@ -28,13 +28,14 @@
 
   matched = jQuery.uaMatch(window.navigator.userAgent)
   browser = {}
-  
+
   if matched.browser
     browser[matched.browser] = true
     browser.version = matched.version
+    browser.versionNumber = parseFloat(matched.version, 10)
 
   browser[matched.platform] = true  if matched.platform
-  
+
   # Chrome, Opera 15+ and Safari are webkit based browsers
   if browser.chrome or browser.opr or browser.safari
     browser.webkit = true


### PR DESCRIPTION
I use this library mainly to check browser versions, and have found that some version numbers don't convert well for comparison. For example, Chrome is currently version 31.0.1650.48, which becomes NaN. I've added browser.versionNumber which uses parseFloat to correctly change this to a number (it will return 31). I recommend using this for any version number checks, rather than the version string.

I also linted the JS file, removing some trailing whitespaces and such.
