### PR TITLE
Fixed path error in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
 	"name": "jquery.browser",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"homepage": "https://github.com/gabceb/jquery-browser-plugin",
 	"authors": ["Gabriel Cebrian <gabceb@gmail.com>", "jQuery Team <https://github.com/gabceb/jquery-browser-plugin/wiki/Authors>"],
 	"description": "A jQuery plugin for browser detection.",
-	"main": "jquery.browser.js",
+	"main": "dist/jquery.browser.js",
 	"keywords": ["browser", "jquery", "desktop", "detect"],
 	"license": "MIT",
 	"dependencies": {


### PR DESCRIPTION
https://github.com/bower/bower.json-spec

The "main" file should be a path to the file, not just a filename. I am using your plugin along with my build tools and it's failing due to this path not being correct.
I have filled similar PRs for lots of other bower plugins before. This seems like a common mistake.

I have also updated to version number, so all you need to do is merge and tag a new release. Which you can do from the github website :) so I'm hoping you can get this in ASAP as in my source code I want to remove the hack I've had to put in place.

Many thanks
