### PR TITLE
Correct plugin coffee edition - Removed javascript 'var' element

### DIFF
--- a/dist/jquery.browser.js.coffee
+++ b/dist/jquery.browser.js.coffee
@@ -42,7 +42,7 @@
     browser.mobile = true
 
   # These are all considered desktop platforms, meaning they run a desktop browser
-  if brower.cros or browser.mac or browser.linux or browser.win
+  if browser.cros or browser.mac or browser.linux or browser.win
     browser.desktop = true
 
   # Chrome, Opera 15+ and Safari are webkit based browsers


### PR DESCRIPTION
I guess this little 'var' element has been forgotten along the way :)
