### PR TITLE
Add a main file which is returned on require

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "jQuery Team <https://github.com/gabceb/jquery-browser-plugin/wiki/Authors>"
   ],
   "description": "A jQuery plugin for browser detection.",
+  "main": "dist/jquery.browser.js",
   "repository": "git@github.com:gabceb/jquery-browser-plugin.git",
   "devDependencies": {
     "webserver": "*",


### PR DESCRIPTION
Point to the `dist/jquery.browser.js` file when requiring this module. At the moment it can't be required by simply doing `require('jquery.browser')`.
