### PR TITLE
Safari version + more

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# EditorConfig.org
+root = true
+
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2

--- a/dist/jquery.browser.js
+++ b/dist/jquery.browser.js
@@ -21,86 +21,88 @@
   jQuery.uaMatch = function( ua ) {
     ua = ua.toLowerCase();
 
-  	var match = /(opr)[\/]([\w.]+)/.exec( ua ) ||
-  		/(chrome)[ \/]([\w.]+)/.exec( ua ) ||
-  		/(version)[ \/]([\w.]+).*(safari)[ \/]([\w.]+)/.exec( ua ) ||
-  		/(webkit)[ \/]([\w.]+)/.exec( ua ) ||
-  		/(opera)(?:.*version|)[ \/]([\w.]+)/.exec( ua ) ||
-  		/(msie) ([\w.]+)/.exec( ua ) ||
-  		ua.indexOf("trident") >= 0 && /(rv)(?::| )([\w.]+)/.exec( ua ) ||
-  		ua.indexOf("compatible") < 0 && /(mozilla)(?:.*? rv:([\w.]+)|)/.exec( ua ) ||
-  		[];
+    var match = /(opr)[\/]([\w.]+)/.exec( ua ) ||
+      /(chrome)[ \/]([\w.]+)/.exec( ua ) ||
+      /(version)(applewebkit)[ \/]([\w.]+).*(safari)[ \/]([\w.]+)/.exec( ua ) ||
+      /(webkit)[ \/]([\w.]+).*(version)[ \/]([\w.]+).*(safari)[ \/]([\w.]+)/.exec( ua ) ||
+      /(webkit)[ \/]([\w.]+)/.exec( ua ) ||
+      /(opera)(?:.*version|)[ \/]([\w.]+)/.exec( ua ) ||
+      /(msie) ([\w.]+)/.exec( ua ) ||
+      ua.indexOf("trident") >= 0 && /(rv)(?::| )([\w.]+)/.exec( ua ) ||
+      ua.indexOf("compatible") < 0 && /(mozilla)(?:.*? rv:([\w.]+)|)/.exec( ua ) ||
+      [];
 
-  	var platform_match = /(ipad)/.exec( ua ) ||
-  		/(iphone)/.exec( ua ) ||
-  		/(android)/.exec( ua ) ||
-  		/(windows phone)/.exec( ua ) ||
-  		/(win)/.exec( ua ) ||
-  		/(mac)/.exec( ua ) ||
-  		/(linux)/.exec( ua ) ||
-  		/(cros)/i.exec( ua ) ||
-  		[];
+    var platform_match = /(ipad)/.exec( ua ) ||
+      /(iphone)/.exec( ua ) ||
+      /(android)/.exec( ua ) ||
+      /(windows phone)/.exec( ua ) ||
+      /(win)/.exec( ua ) ||
+      /(mac)/.exec( ua ) ||
+      /(linux)/.exec( ua ) ||
+      /(cros)/.exec( ua ) ||
+      [];
 
-  	return {
-  		browser: match[ 3 ] || match[ 1 ] || "",
-  		version: match[ 2 ] || "0",
-  		platform: platform_match[ 0 ] || ""
-  	};
+    return {
+      browser: match[ 5 ] || match[ 3 ] || match[ 1 ] || "",
+      version: match[ 2 ] || match[ 4 ],
+      versionNumber: match[ 4 ] || match[ 2 ] || "0",
+      platform: platform_match[ 0 ] || ""
+    };
   };
 
   matched = jQuery.uaMatch( window.navigator.userAgent );
   browser = {};
 
   if ( matched.browser ) {
-  	browser[ matched.browser ] = true;
-  	browser.version = matched.version;
-  	browser.versionNumber = parseInt(matched.version);
+    browser[ matched.browser ] = true;
+    browser.version = matched.version;
+    browser.versionNumber = parseInt(matched.versionNumber);
   }
 
   if ( matched.platform ) {
-  	browser[ matched.platform ] = true;
+    browser[ matched.platform ] = true;
   }
 
   // These are all considered mobile platforms, meaning they run a mobile browser
   if ( browser.android || browser.ipad || browser.iphone || browser[ "windows phone" ] ) {
-  	browser.mobile = true;
+    browser.mobile = true;
   }
 
   // These are all considered desktop platforms, meaning they run a desktop browser
   if ( browser.cros || browser.mac || browser.linux || browser.win ) {
-  	browser.desktop = true;
+    browser.desktop = true;
   }
 
   // Chrome, Opera 15+ and Safari are webkit based browsers
   if ( browser.chrome || browser.opr || browser.safari ) {
-  	browser.webkit = true;
+    browser.webkit = true;
   }
 
   // IE11 has a new token so we will assign it msie to avoid breaking changes
   if ( browser.rv )
   {
-  	var ie = "msie";
+    var ie = "msie";
 
-  	matched.browser = ie;
-  	browser[ie] = true;
+    matched.browser = ie;
+    browser[ie] = true;
   }
 
   // Opera 15+ are identified as opr
   if ( browser.opr )
   {
-  	var opera = "opera";
+    var opera = "opera";
 
-  	matched.browser = opera;
-  	browser[opera] = true;
+    matched.browser = opera;
+    browser[opera] = true;
   }
 
   // Stock Android browsers are marked as Safari on Android.
   if ( browser.safari && browser.android )
   {
-  	var android = "android";
+    var android = "android";
 
-  	matched.browser = android;
-  	browser[android] = true;
+    matched.browser = android;
+    browser[android] = true;
   }
 
   // Assign the name and platform variable

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,6 @@
-test_url = "http://localhost:8008";
+/* global casper, require, $ */
+
+var test_url = "http://localhost:8008";
 
 require('casperserver.js').create(casper);
 casper.server.start();
@@ -7,7 +9,7 @@ casper.on('exit', function(status){
   casper.server.end();
 });
 
-ua = {
+var ua = {
   chrome : {
     windows: "Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1664.3 Safari/537.36",
     mac: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1664.3 Safari/537.36",
@@ -482,7 +484,7 @@ casper.test.begin("when using Opera 15+ on Mac", 7, function(test) {
     test.assert(browser.opera, "Browser should be Opera");
     test.assertEquals(browser.name, ua.opera.name,"Browser name should be " + ua.opera.name);
 
-    test.assertEquals(browser.version, ua.opera.v_15.version, "Version should be " + ua.opera.v_15.version)
+    test.assertEquals(browser.version, ua.opera.v_15.version, "Version should be " + ua.opera.v_15.version);
     test.assertEquals(browser.versionNumber, ua.opera.v_15.versionNumber, "Version number should be " + ua.opera.v_15.versionNumber);
 
     test.assert(browser.desktop, "Browser platform should be desktop");


### PR DESCRIPTION
Should finally finish #35, replaces #37.
- Finish correctly matching Safari `version` and `versionNumber`, with all tests
  passing
- Fix some `var` errors in `test/test.js`
- Add `.editorconfig` (http://EditorConfig.org) to help maintain a consistent
  formatting
- Resolve errors mentioned in #37.
