### PR TITLE
Fix regressions in plugin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@ module.exports = function(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
     jshint: {
-      files: ['gruntfile.js', 'jquery.browser.js', 'test/test.js'],
+      files: ['Gruntfile.js', 'dist/jquery.browser.js', 'test/test.js'],
 
       options: {
         globals: {

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Include script *after* the jQuery library:
 
 ## Usage
 
-Returns true if the current useragent is some version of Microsoft's Internet Explorer. Supports all IE versions including IE11
+Returns true if the current useragent is some version of Microsoft's Internet Explorer. Supports all IE versions including IE 12.
 
     $.browser.msie;
 
@@ -66,7 +66,7 @@ Reading the browser verion
 	$.browser.versionNumber // Returns 32 as a number
 ```
 
-- Support for new useragent on IE11
+- Support for new useragent on IE 11 and IE 12
 - Support for WebKit based Opera browsers
 - Added testing using PhantomJS and different browser user agents
 
@@ -94,6 +94,3 @@ Once Casperjs and the grunt-cli npm package is installed you can execute all the
 
 - [Examples and original implementation](http://api.jquery.com/jQuery.browser/)
 - [Original Gist used for the plugin](https://gist.github.com/adeelejaz/4714079)
-
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/gabceb/jquery-browser-plugin/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-

--- a/dist/jquery.browser.js
+++ b/dist/jquery.browser.js
@@ -17,7 +17,7 @@
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
     define(['jquery'], function ($) {
-        factory($, root);
+      factory($, root);
     });
   } else {
     // Browser globals
@@ -34,7 +34,8 @@
     var match = /(edge)\/([\w.]+)/.exec( ua ) ||
         /(opr)[\/]([\w.]+)/.exec( ua ) ||
         /(chrome)[ \/]([\w.]+)/.exec( ua ) ||
-        /(version)[ \/]([\w.]+).*(safari)[ \/]([\w.]+)/.exec( ua ) ||
+        /(version)(applewebkit)[ \/]([\w.]+).*(safari)[ \/]([\w.]+)/.exec( ua ) ||
+        /(webkit)[ \/]([\w.]+).*(version)[ \/]([\w.]+).*(safari)[ \/]([\w.]+)/.exec( ua ) ||
         /(webkit)[ \/]([\w.]+)/.exec( ua ) ||
         /(opera)(?:.*version|)[ \/]([\w.]+)/.exec( ua ) ||
         /(msie) ([\w.]+)/.exec( ua ) ||
@@ -49,12 +50,13 @@
         /(win)/.exec( ua ) ||
         /(mac)/.exec( ua ) ||
         /(linux)/.exec( ua ) ||
-        /(cros)/i.exec( ua ) ||
+        /(cros)/.exec( ua ) ||
         [];
 
     return {
-      browser: match[ 3 ] || match[ 1 ] || "",
-      version: match[ 2 ] || "0",
+      browser: match[ 5 ] || match[ 3 ] || match[ 1 ] || "",
+      version: match[ 2 ] || match[ 4 ] || "0",
+      versionNumber: match[ 4 ] || match[ 2 ] || "0",
       platform: platform_match[ 0 ] || ""
     };
   };
@@ -65,7 +67,7 @@
   if ( matched.browser ) {
     browser[ matched.browser ] = true;
     browser.version = matched.version;
-    browser.versionNumber = parseInt(matched.version);
+    browser.versionNumber = parseInt(matched.versionNumber, 10);
   }
 
   if ( matched.platform ) {

--- a/test/test.js
+++ b/test/test.js
@@ -398,30 +398,6 @@ casper.test.begin("when using IE10", 7, function(test) {
   });
 });
 
-casper.test.begin("when using IE11", 7, function(test) {
-  casper.userAgent(ua.ie.windows.v_11);
-
-  casper.start(test_url).then(function(){
-
-    var browser = casper.evaluate(function(){
-      return $.browser;
-    });
-
-    test.assert(browser.msie, "Browser should be IE");
-    test.assertEquals(browser.name, ua.ie.name,"Browser name should be " + ua.ie.name);
-
-    test.assertEquals(browser.version, "11.0", "Version should be 11.0");
-    test.assertEquals(browser.versionNumber, 11, "Version should be 11");
-
-    test.assert(browser.desktop, "Browser platform should be desktop");
-    test.assert(browser.win, "Platform should be Windows");
-
-    test.assertFalsy(browser.webkit, "Browser should NOT be WebKit based");
-
-  }).run(function(){
-   test.done();
-  });
-});
 
 casper.test.begin("when using IE10 on a Windows Phone", 7, function(test) {
   casper.userAgent(ua.ie.win_phone.v_10);
@@ -440,6 +416,31 @@ casper.test.begin("when using IE10 on a Windows Phone", 7, function(test) {
 
     test.assert(browser.mobile, "Browser platform should be mobile");
     test.assert(browser["windows phone"], "Platform should be Windows Phone");
+
+    test.assertFalsy(browser.webkit, "Browser should NOT be WebKit based");
+
+  }).run(function(){
+    test.done();
+  });
+});
+
+casper.test.begin("when using IE11", 7, function(test) {
+  casper.userAgent(ua.ie.windows.v_11);
+
+  casper.start(test_url).then(function(){
+
+    var browser = casper.evaluate(function(){
+      return $.browser;
+    });
+
+    test.assert(browser.msie, "Browser should be IE");
+    test.assertEquals(browser.name, ua.ie.name,"Browser name should be " + ua.ie.name);
+
+    test.assertEquals(browser.version, "11.0", "Version should be 11.0");
+    test.assertEquals(browser.versionNumber, 11, "Version should be 11");
+
+    test.assert(browser.desktop, "Browser platform should be desktop");
+    test.assert(browser.win, "Platform should be Windows");
 
     test.assertFalsy(browser.webkit, "Browser should NOT be WebKit based");
 


### PR DESCRIPTION
This will fix #46. This is funny because the fix is identical to #44, but I closed that in order to fix this and said I would look at it later.
- Fix issues described in #46
- #35 is confirmed to still be fixed
- Add support for `AppleWebKit`
- Fix Gruntfile to lint script (and fixed error caught by it)
- The IE 11 test was placed in the middle of the IE 10 tests, fix placement of that
- Update README to reflect IE 12 support
- BitDeli is no longer of use due to changes GitHub made in README images. The same data can now be viewed in the Pulse and Graphs tabs.

/cc @gabceb @bhamodi
