### PR TITLE
Support for node/browserify

### DIFF
--- a/dist/jquery.browser.js
+++ b/dist/jquery.browser.js
@@ -12,7 +12,6 @@
  *
  * Date: 12-12-2014
  */
-
 /*global window: false */
 
 (function (factory) {


### PR DESCRIPTION
Fixes two compatibility issues:
1. Inside wrapped browserify modules, `this` does not refer to `window`,
    it's the `exports` object. Since it doesn't really make sense to use
    this plugin in environments that don't have a window.navigator object,
    the code now just references 'window' directly.
2. The plugin did a global export if AMD wasn't detected, which assumed
    there was a global jQuery object. The added `module.exports`-detection
    uses `require` to pull in jQuery instead.
