### PR TITLE
bugfix windows phone (lumia520)

### DIFF
--- a/dist/jquery.browser.js
+++ b/dist/jquery.browser.js
@@ -40,6 +40,7 @@
     var match = /(edge)\/([\w.]+)/.exec( ua ) ||
         /(opr)[\/]([\w.]+)/.exec( ua ) ||
         /(chrome)[ \/]([\w.]+)/.exec( ua ) ||
+        /(iemobile)[\/]([\w.]+)/.exec( ua ) ||
         /(version)(applewebkit)[ \/]([\w.]+).*(safari)[ \/]([\w.]+)/.exec( ua ) ||
         /(webkit)[ \/]([\w.]+).*(version)[ \/]([\w.]+).*(safari)[ \/]([\w.]+)/.exec( ua ) ||
         /(webkit)[ \/]([\w.]+)/.exec( ua ) ||
@@ -51,11 +52,11 @@
 
     var platform_match = /(ipad)/.exec( ua ) ||
         /(ipod)/.exec( ua ) ||
+        /(windows phone)/.exec( ua ) ||
         /(iphone)/.exec( ua ) ||
         /(kindle)/.exec( ua ) ||
         /(silk)/.exec( ua ) ||
         /(android)/.exec( ua ) ||
-        /(windows phone)/.exec( ua ) ||
         /(win)/.exec( ua ) ||
         /(mac)/.exec( ua ) ||
         /(linux)/.exec( ua ) ||
@@ -101,7 +102,7 @@
 
     // IE11 has a new token so we will assign it msie to avoid breaking changes
     // IE12 disguises itself as Chrome, but adds a new Edge token.
-    if ( browser.rv || browser.edge ) {
+    if ( browser.rv || browser.edge || browser.iemobile) {
       var ie = "msie";
 
       matched.browser = ie;


### PR DESCRIPTION
Windows Phone - Lumia 520 - UA: 
```javascript
"mozilla/5.0 (mobile; windows phone 8.1; android 4.0; arm; trident/7.0; touch; rv:11.0; iemobile/11.0; nokia; lumia 520) like iphone os 7_0_3 mac os x applewebkit/537 (khtml, like gecko) mobile safari/537"
```

Buged:
```javascript
{"webkit":true,"version":"537","versionNumber":537,"iphone":true,"mobile":true,"name":"webkit","platform":"iphone"}
```

Bugfixed:
```javascript
{iemobile":true,"version":"11.0","versionNumber":11,"windows phone":true,"mobile":true,"msie":true,"name":"msie","platform":"windows phone"}
```


