### PR TITLE
Correctly detect Windows Phone 8.1 Lumia 520

### DIFF
--- a/dist/jquery.browser.js
+++ b/dist/jquery.browser.js
@@ -40,6 +40,7 @@
     var match = /(edge)\/([\w.]+)/.exec( ua ) ||
         /(opr)[\/]([\w.]+)/.exec( ua ) ||
         /(chrome)[ \/]([\w.]+)/.exec( ua ) ||
+        /(iemobile)[\/]([\w.]+)/.exec( ua ) ||
         /(version)(applewebkit)[ \/]([\w.]+).*(safari)[ \/]([\w.]+)/.exec( ua ) ||
         /(webkit)[ \/]([\w.]+).*(version)[ \/]([\w.]+).*(safari)[ \/]([\w.]+)/.exec( ua ) ||
         /(webkit)[ \/]([\w.]+)/.exec( ua ) ||
@@ -51,11 +52,11 @@
 
     var platform_match = /(ipad)/.exec( ua ) ||
         /(ipod)/.exec( ua ) ||
+        /(windows phone)/.exec( ua ) ||
         /(iphone)/.exec( ua ) ||
         /(kindle)/.exec( ua ) ||
         /(silk)/.exec( ua ) ||
         /(android)/.exec( ua ) ||
-        /(windows phone)/.exec( ua ) ||
         /(win)/.exec( ua ) ||
         /(mac)/.exec( ua ) ||
         /(linux)/.exec( ua ) ||
@@ -101,7 +102,7 @@
 
     // IE11 has a new token so we will assign it msie to avoid breaking changes
     // IE12 disguises itself as Chrome, but adds a new Edge token.
-    if ( browser.rv || browser.edge ) {
+    if ( browser.rv || browser.edge || browser.iemobile) {
       var ie = "msie";
 
       matched.browser = ie;

--- a/test/test.js
+++ b/test/test.js
@@ -464,7 +464,6 @@ casper.test.begin("when using IE10", 7, function(test) {
   });
 });
 
-
 casper.test.begin("when using IE10 on a Windows Phone", 7, function(test) {
   casper.userAgent(ua.ie.win_phone.v_10);
 
@@ -479,6 +478,31 @@ casper.test.begin("when using IE10 on a Windows Phone", 7, function(test) {
 
     test.assertEquals(browser.version, "10.0", "Version should be 10.0");
     test.assertEquals(browser.versionNumber, 10, "Version should be 10");
+
+    test.assert(browser.mobile, "Browser platform should be mobile");
+    test.assert(browser["windows phone"], "Platform should be Windows Phone");
+
+    test.assertFalsy(browser.webkit, "Browser should NOT be WebKit based");
+
+  }).run(function(){
+    test.done();
+  });
+});
+
+casper.test.begin("when using IE11 on a Windows Phone", 7, function(test) {
+  casper.userAgent(ua.ie.win_phone.v_11);
+
+  casper.start(test_url).then(function(){
+
+    var browser = casper.evaluate(function(){
+      return $.browser;
+    });
+
+    test.assert(browser.msie, "Browser should be IE");
+    test.assertEquals(browser.name, ua.ie.name,"Browser name should be " + ua.ie.name);
+
+    test.assertEquals(browser.version, "11.0", "Version should be 11.0");
+    test.assertEquals(browser.versionNumber, 11, "Version should be 11");
 
     test.assert(browser.mobile, "Browser platform should be mobile");
     test.assert(browser["windows phone"], "Platform should be Windows Phone");

--- a/test/test.js
+++ b/test/test.js
@@ -47,7 +47,8 @@ var ua = {
       v_12: "Mozilla/5.0 (Windows NT 6.4; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.143 Safari/537.36 Edge/12.0"
     },
     win_phone : {
-      v_10: "Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 1020)"
+      v_10: "Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 1020)",
+      v_11: "Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 520) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537"
     },
     name: "msie"
   },


### PR DESCRIPTION
Fixes #67. This pulls @MoonYard's two PRs (#68 and #69) and adds a missing test for the new UA.