### PR TITLE
Support Microsoft Edge (Windows and Windows Phone)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You can also examine arbitrary useragents
 	$.browser.kindle
 	$.browser.linux
 	$.browser.mac
+	$.browser.msedge
 	$.browser.playbook
 	$.browser.silk
 	$.browser.win
@@ -86,6 +87,7 @@ Alternatively, you can detect for generic classifications such as desktop or mob
 ```
 
 - Support for new useragent on IE 11
+- Support for Microsoft Edge
 - Support for WebKit based Opera browsers
 - Added testing using PhantomJS and different browser user agents
 

--- a/dist/jquery.browser.js
+++ b/dist/jquery.browser.js
@@ -101,12 +101,20 @@
     }
 
     // IE11 has a new token so we will assign it msie to avoid breaking changes
-    // IE12 disguises itself as Chrome, but adds a new Edge token.
-    if ( browser.rv || browser.edge || browser.iemobile) {
+    if ( browser.rv || browser.iemobile) {
       var ie = "msie";
 
       matched.browser = ie;
       browser[ie] = true;
+    }
+
+    // Edge is officially known as Microsoft Edge, so rewrite the key to match
+    if ( browser.edge ) {
+      delete browser.edge;
+      var msedge = "msedge";
+
+      matched.browser = msedge;
+      browser[msedge] = true;
     }
 
     // Blackberry browsers are marked as Safari on BlackBerry

--- a/test/test.js
+++ b/test/test.js
@@ -40,17 +40,26 @@ var ua = {
     name: "mozilla"
   },
   ie: {
-    windows : {
+    windows: {
       v_9: "Mozilla/4.0 (compatible; MSIE 9.0; Windows NT 6.0; Trident/5.0)",
       v_10: "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)",
-      v_11: "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko",
-      v_12: "Mozilla/5.0 (Windows NT 6.4; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.143 Safari/537.36 Edge/12.0"
+      v_11: "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko"
     },
-    win_phone : {
+    win_phone: {
       v_10: "Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 1020)",
       v_11: "Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 520) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537"
     },
     name: "msie"
+  },
+  msedge: {
+    windows: {
+      v_12: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.0",
+      v_13: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586"
+    },
+    win_phone: {
+      v_13: "Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; NOKIA; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Mobile Safari/537.36 Edge/13.10586"
+    },
+    name: "msedge"
   },
   opera: {
     v_15: {
@@ -489,31 +498,6 @@ casper.test.begin("when using IE10 on a Windows Phone", 7, function(test) {
   });
 });
 
-casper.test.begin("when using IE11 on a Windows Phone", 7, function(test) {
-  casper.userAgent(ua.ie.win_phone.v_11);
-
-  casper.start(test_url).then(function(){
-
-    var browser = casper.evaluate(function(){
-      return $.browser;
-    });
-
-    test.assert(browser.msie, "Browser should be IE");
-    test.assertEquals(browser.name, ua.ie.name,"Browser name should be " + ua.ie.name);
-
-    test.assertEquals(browser.version, "11.0", "Version should be 11.0");
-    test.assertEquals(browser.versionNumber, 11, "Version should be 11");
-
-    test.assert(browser.mobile, "Browser platform should be mobile");
-    test.assert(browser["windows phone"], "Platform should be Windows Phone");
-
-    test.assertFalsy(browser.webkit, "Browser should NOT be WebKit based");
-
-  }).run(function(){
-    test.done();
-  });
-});
-
 casper.test.begin("when using IE11", 7, function(test) {
   casper.userAgent(ua.ie.windows.v_11);
 
@@ -539,8 +523,8 @@ casper.test.begin("when using IE11", 7, function(test) {
   });
 });
 
-casper.test.begin("when using IE12", 7, function(test) {
-  casper.userAgent(ua.ie.windows.v_12);
+casper.test.begin("when using IE11 on a Windows Phone", 7, function(test) {
+  casper.userAgent(ua.ie.win_phone.v_11);
 
   casper.start(test_url).then(function(){
 
@@ -550,6 +534,31 @@ casper.test.begin("when using IE12", 7, function(test) {
 
     test.assert(browser.msie, "Browser should be IE");
     test.assertEquals(browser.name, ua.ie.name,"Browser name should be " + ua.ie.name);
+
+    test.assertEquals(browser.version, "11.0", "Version should be 11.0");
+    test.assertEquals(browser.versionNumber, 11, "Version should be 11");
+
+    test.assert(browser.mobile, "Browser platform should be mobile");
+    test.assert(browser["windows phone"], "Platform should be Windows Phone");
+
+    test.assertFalsy(browser.webkit, "Browser should NOT be WebKit based");
+
+  }).run(function(){
+    test.done();
+  });
+});
+
+casper.test.begin("when using Microsoft Edge 12", 7, function(test) {
+  casper.userAgent(ua.msedge.windows.v_12);
+
+  casper.start(test_url).then(function(){
+
+    var browser = casper.evaluate(function(){
+      return $.browser;
+    });
+
+    test.assert(browser.msedge, "Browser should be MS Edge");
+    test.assertEquals(browser.name, ua.msedge.name,"Browser name should be " + ua.msedge.name);
 
     test.assertEquals(browser.version, "12.0", "Version should be 12.0");
     test.assertEquals(browser.versionNumber, 12, "Version should be 12");
@@ -563,6 +572,57 @@ casper.test.begin("when using IE12", 7, function(test) {
    test.done();
   });
 });
+
+casper.test.begin("when using Microsoft Edge 13", 7, function(test) {
+  casper.userAgent(ua.msedge.windows.v_13);
+
+  casper.start(test_url).then(function(){
+
+    var browser = casper.evaluate(function(){
+      return $.browser;
+    });
+
+    test.assert(browser.msedge, "Browser should be MS Edge");
+    test.assertEquals(browser.name, ua.msedge.name,"Browser name should be " + ua.msedge.name);
+
+    test.assertEquals(browser.version, "13.10586", "Version should be 13.10586");
+    test.assertEquals(browser.versionNumber, 13, "Version should be 13");
+
+    test.assert(browser.desktop, "Browser platform should be desktop");
+    test.assert(browser.win, "Platform should be Windows");
+
+    test.assertFalsy(browser.webkit, "Browser should NOT be WebKit based");
+
+  }).run(function(){
+   test.done();
+  });
+});
+
+casper.test.begin("when using Microsoft Edge v13 on a Windows Phone", 7, function(test) {
+  casper.userAgent(ua.msedge.win_phone.v_13);
+
+  casper.start(test_url).then(function(){
+
+    var browser = casper.evaluate(function(){
+      return $.browser;
+    });
+
+    test.assert(browser.msedge, "Browser should be MS Edge");
+    test.assertEquals(browser.name, ua.msedge.name,"Browser name should be " + ua.msedge.name);
+
+    test.assertEquals(browser.version, "13.10586", "Version should be 13.10586");
+    test.assertEquals(browser.versionNumber, 13, "Version should be 13");
+
+    test.assert(browser.mobile, "Browser platform should be mobile");
+    test.assert(browser["windows phone"], "Platform should be Windows Phone");
+
+    test.assertFalsy(browser.webkit, "Browser should NOT be WebKit based");
+
+  }).run(function(){
+    test.done();
+  });
+});
+
 
 casper.test.begin("when using Opera 15+ on Windows", 7, function(test) {
   casper.userAgent(ua.opera.v_15.windows);


### PR DESCRIPTION
Fixes #63. All relevant keys are named `msedge`. Also swap the running order of the IE 11 tests (desktop, then Windows Phone).

As I suspected, we already correctly detected Edge but stuffed it under IE (as version 12). With minor refactoring I was able to correctly expose Edge.

FYI on the Edge versioning, see [this post](http://blogs.windows.com/msedgedev/2015/09/21/understanding-versions-in-an-evergreen-browser/) on the MS Edge dev blog.